### PR TITLE
perf: 50% faster aqi compute on single var

### DIFF
--- a/aqi.go
+++ b/aqi.go
@@ -68,8 +68,9 @@ type StandardWithColor interface {
 }
 
 func GetRanges(value float64, pIndexRange []float64, aqiIndexRange []float64) (iaqiLo, iaqiHi, pLo, pHi float64, err error) {
+	lastIdx := len(pIndexRange) - 1
 	for i, v := range pIndexRange {
-		if i == len(pIndexRange)-1 {
+		if i == lastIdx {
 			return aqiIndexRange[i-1], aqiIndexRange[i], pIndexRange[i-1], v, nil
 		}
 		if pIndexRange[i] < value && value <= pIndexRange[i+1] {

--- a/epa/epa.go
+++ b/epa/epa.go
@@ -67,11 +67,11 @@ func (a *Algo) Name() string {
 // Calc is func for realtime AQI report computing.
 func (a *Algo) Calc(pollutantVars ...*goaqi.Var) (int, []goaqi.Pollutant, error) {
 	var (
-		results = make(map[goaqi.Pollutant]int)
+		results = make([]*goaqi.Var, len(pollutantVars))
 		maxAQI  int
 	)
 
-	for _, pollutantVar := range pollutantVars {
+	for idx, pollutantVar := range pollutantVars {
 		pollutantIndexRange, ok := tables[pollutantVar.P]
 		if !ok {
 			continue
@@ -106,15 +106,15 @@ func (a *Algo) Calc(pollutantVars ...*goaqi.Var) (int, []goaqi.Pollutant, error)
 		if aqi > maxAQI {
 			maxAQI = aqi
 		}
-		results[pollutantVar.P] = aqi
+		results[idx] = &goaqi.Var{P: pollutantVar.P, Value: float64(aqi)}
 	}
 	if maxAQI <= 50 {
 		return maxAQI, nil, nil
 	}
-	primaryPollutants := make([]goaqi.Pollutant, 0)
-	for pollutant, value := range results {
-		if value == maxAQI {
-			primaryPollutants = append(primaryPollutants, pollutant)
+	primaryPollutants := make([]goaqi.Pollutant, 0, len(pollutantVars)) // Set cap can reduce 10ns when append value to slice per time.
+	for _, result := range results {
+		if result.Value == float64(maxAQI) {
+			primaryPollutants = append(primaryPollutants, result.P)
 		}
 	}
 	return maxAQI, primaryPollutants, nil


### PR DESCRIPTION
## Single var

```bash
go test -benchmem -run=^$ -bench ^BenchmarkAlgoCalcOnSingleDataset$ github.com/ringsaturn/go-aqi/mep ./... > old.txt
```

```
goos: darwin
goarch: arm64
pkg: github.com/ringsaturn/go-aqi/mep
BenchmarkAlgoCalcOnSingleDataset-16    	12619250	        94.83 ns/op	      56 B/op	       3 allocs/op
PASS
ok  	github.com/ringsaturn/go-aqi/mep	2.531s
PASS
ok  	github.com/ringsaturn/go-aqi	0.424s
PASS
ok  	github.com/ringsaturn/go-aqi/epa	0.428s
```

```bash
go test -benchmem -run=^$ -bench ^BenchmarkAlgoCalcOnSingleDataset$ github.com/ringsaturn/go-aqi/mep ./... > new.txt
```

```
goos: darwin
goarch: arm64
pkg: github.com/ringsaturn/go-aqi/mep
BenchmarkAlgoCalcOnSingleDataset-16    	26883134	        44.82 ns/op	      28 B/op	       3 allocs/op
PASS
ok  	github.com/ringsaturn/go-aqi/mep	2.666s
PASS
ok  	github.com/ringsaturn/go-aqi	0.498s
PASS
ok  	github.com/ringsaturn/go-aqi/epa	0.425s
```

```
➜  go-aqi git:(ringsaturn/perf) ✗ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/ringsaturn/go-aqi/mep
                           │   old.txt    │             new.txt             │
                           │    sec/op    │    sec/op     vs base           │
AlgoCalcOnSingleDataset-16   94.83n ± ∞ ¹   44.82n ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                           │   old.txt   │            new.txt             │
                           │    B/op     │    B/op      vs base           │
AlgoCalcOnSingleDataset-16   56.00 ± ∞ ¹   28.00 ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                           │   old.txt   │            new.txt             │
                           │  allocs/op  │  allocs/op   vs base           │
AlgoCalcOnSingleDataset-16   3.000 ± ∞ ¹   3.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
```

## Multi Var 384 steps:

```
benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/ringsaturn/go-aqi/mep
                       │   old.txt    │             new.txt             │
                       │    sec/op    │    sec/op     vs base           │
AlgoCalcOnLargeData-16   82.76µ ± ∞ ¹   68.59µ ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                       │    old.txt    │             new.txt              │
                       │     B/op      │     B/op       vs base           │
AlgoCalcOnLargeData-16   21.00Ki ± ∞ ¹   63.00Ki ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                       │   old.txt    │             new.txt             │
                       │  allocs/op   │  allocs/op    vs base           │
AlgoCalcOnLargeData-16   1.152k ± ∞ ¹   3.072k ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```

`old.txt`:

```
goos: darwin
goarch: arm64
pkg: github.com/ringsaturn/go-aqi/mep
BenchmarkAlgoCalcOnLargeData-16    	   14083	     82763 ns/op	   21504 B/op	    1152 allocs/op
PASS
ok  	github.com/ringsaturn/go-aqi/mep	2.245s
PASS
ok  	github.com/ringsaturn/go-aqi	0.302s
PASS
ok  	github.com/ringsaturn/go-aqi/epa	0.328s
```


`new.txt`:

```
goos: darwin
goarch: arm64
pkg: github.com/ringsaturn/go-aqi/mep
BenchmarkAlgoCalcOnLargeData-16    	   18598	     68586 ns/op	   64512 B/op	    3072 allocs/op
PASS
ok  	github.com/ringsaturn/go-aqi/mep	2.413s
PASS
ok  	github.com/ringsaturn/go-aqi	0.403s
PASS
ok  	github.com/ringsaturn/go-aqi/epa	0.415s
```